### PR TITLE
docker2rootfs: move to oci-distribution

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,6 +8,8 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # Make sure CI fails on all warnings, including Clippy lints
+  RUSTFLAGS: "-Dwarnings"
 
 jobs:
   build:
@@ -20,3 +22,7 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+    - name: Run Clippy
+      run: cargo clippy --all-targets --all-features
+    - name: Run rustfmt
+      run: cargo fmt --check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -97,28 +112,6 @@ name = "anyhow"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
-
-[[package]]
-name = "async-stream"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
-]
 
 [[package]]
 name = "autocfg"
@@ -202,6 +195,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-targets 0.52.0",
+]
+
+[[package]]
 name = "clap"
 version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,10 +237,10 @@ version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
 ]
 
 [[package]]
@@ -314,33 +322,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
-]
-
-[[package]]
-name = "dkregistry"
-version = "0.5.1-alpha.0"
-source = "git+https://github.com/chantra/camallo-dkregistry-rs.git?branch=wip#035f1a50f4cfc4b67044381ae3e469e563524483"
-dependencies = [
- "async-stream",
- "base64 0.13.1",
- "bytes",
- "futures",
- "libflate 1.2.0",
- "log",
- "mime",
- "pin-project",
- "regex",
- "reqwest",
- "serde",
- "serde_ignored",
- "serde_json",
- "sha2",
- "strum",
- "strum_macros",
- "tar",
- "thiserror",
- "tokio",
- "url",
+ "subtle",
 ]
 
 [[package]]
@@ -349,10 +331,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
- "dkregistry",
  "env_logger",
  "futures",
- "libflate 2.0.0",
+ "libflate",
+ "oci-distribution",
  "tar",
  "thiserror",
  "tokio",
@@ -503,7 +485,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
 ]
 
 [[package]]
@@ -588,15 +570,6 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
@@ -608,6 +581,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d3d0e0f38255e7fa3cf31335b3a56f05febd18025f4db5ef7a0cfb4f8da651f"
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "http"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,6 +598,15 @@ dependencies = [
  "bytes",
  "fnv",
  "itoa",
+]
+
+[[package]]
+name = "http-auth"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643c9bbf6a4ea8a656d6b4cd53d34f79e3f841ad5203c1a55fb7d761923bc255"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -685,6 +676,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -737,6 +751,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jwt"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6204285f77fe7d9784db3fdc449ecce1a0114927a51d5a41c4c7a292011c015f"
+dependencies = [
+ "base64 0.13.1",
+ "crypto-common",
+ "digest",
+ "hmac",
+ "serde",
+ "serde_json",
+ "sha2",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -750,17 +779,6 @@ checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
 name = "libflate"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05605ab2bce11bcfc0e9c635ff29ef8b2ea83f29be257ee7d730cac3ee373093"
-dependencies = [
- "adler32",
- "crc32fast",
- "libflate_lz77 1.2.0",
-]
-
-[[package]]
-name = "libflate"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7d5654ae1795afc7ff76f4365c2c8791b0feb18e8996a96adad8ffd7c3b2bf"
@@ -769,16 +787,7 @@ dependencies = [
  "core2",
  "crc32fast",
  "dary_heap",
- "libflate_lz77 2.0.0",
-]
-
-[[package]]
-name = "libflate_lz77"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a52d3a8bfc85f250440e4424db7d857e241a3aebbbe301f3eb606ab15c39acbf"
-dependencies = [
- "rle-decode-fast",
+ "libflate_lz77",
 ]
 
 [[package]]
@@ -865,6 +874,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -881,6 +899,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "oci-distribution"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a635cabf7a6eb4e5f13e9e82bd9503b7c2461bf277132e38638a935ebd684b4"
+dependencies = [
+ "bytes",
+ "chrono",
+ "futures-util",
+ "http",
+ "http-auth",
+ "jwt",
+ "lazy_static",
+ "olpc-cjson",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "unicase",
+]
+
+[[package]]
+name = "olpc-cjson"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d637c9c15b639ccff597da8f4fa968300651ad2f1e968aefc3b4927a6fb2027a"
+dependencies = [
+ "serde",
+ "serde_json",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -912,7 +966,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
 ]
 
 [[package]]
@@ -944,26 +998,6 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
-
-[[package]]
-name = "pin-project"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0302c4a0442c456bd56f841aee5c3bfd17967563f6fadc9ceb9f9c23cf3807e0"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
-]
 
 [[package]]
 name = "pin-project-lite"
@@ -1105,12 +1139,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
-
-[[package]]
 name = "ryu"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1165,16 +1193,7 @@ checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
-]
-
-[[package]]
-name = "serde_ignored"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8e319a36d1b52126a0d608f24e93b2d81297091818cd70625fcf50a15d84ddf"
-dependencies = [
- "serde",
+ "syn",
 ]
 
 [[package]]
@@ -1252,34 +1271,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
-name = "strum"
-version = "0.23.0"
+name = "subtle"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cae14b91c7d11c9a851d3fbc80a963198998c2a64eec840477fa92d8ce9b70bb"
-
-[[package]]
-name = "strum_macros"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
-dependencies = [
- "heck 0.3.3",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
@@ -1363,7 +1358,7 @@ checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
 ]
 
 [[package]]
@@ -1416,7 +1411,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
 ]
 
 [[package]]
@@ -1469,7 +1464,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
 ]
 
 [[package]]
@@ -1520,6 +1515,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
+name = "unicase"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1539,12 +1543,6 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "url"
@@ -1627,7 +1625,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -1661,7 +1659,7 @@ checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1725,6 +1723,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.0",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1896,5 +1903,5 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
 ]

--- a/docker2rootfs/Cargo.toml
+++ b/docker2rootfs/Cargo.toml
@@ -10,8 +10,7 @@ license = "BSD-2"
 [dependencies]
 anyhow = "1"
 clap = { version = "4.4.18", features = ["derive", "string"] }
-dkregistry = { version = "0.5.1-alpha.0", git = "https://github.com/chantra/camallo-dkregistry-rs.git", branch = "wip" }
-#dkregistry = { path = '../../camallo-dkregistry-rs' }
+oci-distribution = "0.10"
 env_logger = "0.10"
 futures = "0.3"
 libflate = "2"

--- a/docker2rootfs/src/main.rs
+++ b/docker2rootfs/src/main.rs
@@ -4,6 +4,11 @@ use std::path::PathBuf;
 use anyhow::{Context, Result};
 use clap::Parser;
 use futures::future::try_join_all;
+use oci_distribution::{
+    manifest::{OciImageManifest, OciManifest},
+    secrets::RegistryAuth,
+    Client, Reference,
+};
 use tracing::{debug, info, trace};
 
 mod render;
@@ -39,23 +44,27 @@ struct Args {
     output: PathBuf,
 }
 
-async fn download_layer(
-    client: &dkregistry::v2::Client,
-    image: &str,
-    layer_digest: &str,
-    cache_dir: Option<&PathBuf>,
-) -> Result<Vec<u8>> {
-    if cache_dir.is_some() {
-        let cache_path = cache_dir.unwrap().join(layer_digest);
+async fn download_layer(client: &Client, args: &Args, layer_digest: &str) -> Result<Vec<u8>> {
+    if args.cache.is_some() {
+        let cache_path = args.cache.as_ref().unwrap().join(layer_digest);
         if cache_path.exists() {
             debug!("Using cached layer {}", layer_digest);
             return fs::read(cache_path)
                 .context(format!("Failed to read cached layer {}", layer_digest));
         }
     }
-    let blob = client.get_blob(image, layer_digest).await?;
-    if cache_dir.is_some() {
-        let cache_path = cache_dir.unwrap().join(layer_digest);
+    let reference = Reference::with_digest(
+        args.registry.clone(),
+        args.image.clone(),
+        layer_digest.to_string(),
+    );
+
+    let mut blob: Vec<u8> = Vec::new();
+    client
+        .pull_blob(&reference, layer_digest, &mut blob)
+        .await?;
+    if args.cache.is_some() {
+        let cache_path = args.cache.as_ref().unwrap().join(layer_digest);
         debug!("Caching layer {}", layer_digest);
         fs::write(cache_path, &blob).context(format!("Failed to cache layer {}", layer_digest))?;
     }
@@ -67,21 +76,47 @@ async fn download_layer(
 /// Otherwise, return the Image manifest originally returned by the API.
 /// Errors if this is an OCI image list and no architecture flag was passed, or if no image manifest matches the architecture.
 async fn get_manifest(
-    client: &dkregistry::v2::Client,
+    client: &mut Client,
+    auth: &RegistryAuth,
     args: &Args,
-) -> Result<dkregistry::v2::manifest::Manifest> {
-    let mut manifest = client.get_manifest(&args.image, &args.reference).await?;
+) -> Result<OciImageManifest> {
+    // Build a URL which will be accepted by oci-distribution.
+    let reference = Reference::with_tag(
+        args.registry.clone(),
+        args.image.clone(),
+        args.reference.clone(),
+    );
+    let (manifest, _) = client
+        .pull_manifest(&reference, auth)
+        .await
+        .expect("Cannot pull manifest");
+
     match manifest {
-        dkregistry::v2::manifest::Manifest::ML(ml) => {
-            debug!("Got an Image List, finding matching platform.");
-            trace!("Image List: {:?}", ml);
+        OciManifest::ImageIndex(ii) => {
+            debug!("Got an OCI Image Index, finding matching platform.");
+            trace!("Image List: {:?}", ii);
             if args.architecture.is_none() {
-                return Err(anyhow::anyhow!("This image is availale for multiple architectures, you need to specify which one you want with --architecture flag."));
+                return Err(anyhow::anyhow!("This image is available for multiple architectures, you need to specify which one you want with --architecture flag."));
             }
-            for item in ml.manifests {
-                if Some(item.architecture()) == args.architecture {
-                    manifest = client.get_manifest(&args.image, &item.digest).await?;
-                    return Ok(manifest);
+            for item in ii.manifests {
+                if item
+                    .platform
+                    .is_some_and(|p| Some(p.architecture) == args.architecture)
+                {
+                    let reference = Reference::with_digest(
+                        args.registry.clone(),
+                        args.image.clone(),
+                        item.digest,
+                    );
+
+                    let (manifest, _) = client
+                        .pull_manifest(&reference, auth)
+                        .await
+                        .expect("Cannot pull manifest");
+                    match manifest {
+                        OciManifest::Image(manifest) => return Ok(manifest),
+                        _ => unreachable!(),
+                    }
                 }
             }
             Err(anyhow::anyhow!(
@@ -89,7 +124,7 @@ async fn get_manifest(
                 args.architecture.as_ref().unwrap()
             ))
         }
-        _ => Ok(manifest),
+        OciManifest::Image(manifest) => Ok(manifest),
     }
 }
 
@@ -117,31 +152,27 @@ async fn main() -> Result<()> {
         anyhow::bail!("Output directory {} is not empty", args.output.display());
     }
 
-    let client = dkregistry::v2::Client::configure()
-        .registry(&args.registry)
-        .insecure_registry(false)
-        .build()?;
-
-    let login_scope = format!("repository:{}:pull", args.image);
-    let dclient = client.authenticate(&[&login_scope]).await?;
-    let manifest = get_manifest(&dclient, &args).await.unwrap_or_else(|_| {
-        panic!(
-            "Did not find a manifest for {}:{}",
-            args.image, args.reference
-        )
+    let auth = RegistryAuth::Anonymous;
+    let mut client = Client::new(oci_distribution::client::ClientConfig {
+        ..Default::default()
     });
 
+    let manifest = get_manifest(&mut client, &auth, &args).await?;
+
     trace!("Manifest: {:?}", manifest);
-    let layers_digests = manifest.layers_digests(None)?;
+
+    let layers_digests: Vec<_> = manifest
+        .layers
+        .iter()
+        .map(|layer| layer.digest.clone())
+        .collect();
 
     trace!("Layers digests: {:?}", layers_digests);
     info!("Downloading {} layer(s)", layers_digests.len());
 
     let blob_futures = layers_digests
         .iter()
-        .map(|layer_digest| {
-            download_layer(&dclient, &args.image, layer_digest, args.cache.as_ref())
-        })
+        .map(|layer_digest| download_layer(&client, &args, layer_digest))
         .collect::<Vec<_>>();
     let blobs = try_join_all(blob_futures).await?;
 
@@ -151,5 +182,6 @@ async fn main() -> Result<()> {
 
     let canonical_path = args.output.canonicalize().unwrap();
     render::unpack(&blobs, &canonical_path)?;
+
     Ok(())
 }


### PR DESCRIPTION
oci-distribution crate is actively maintained. Let's use this instead.